### PR TITLE
Depend freerdp2-dev on libfreerdp-shadow2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -157,6 +157,7 @@ Depends:
  libfreerdp2 (= ${binary:Version}),
  libfreerdp-server2 (= ${binary:Version}),
  libfreerdp-client2 (= ${binary:Version}),
+ libfreerdp-shadow2 (= ${binary:Version}),
  librdtk2 (= ${binary:Version}),
 Description: Free Remote Desktop Protocol library (development files)
  FreeRDP is a libre client/server implementation of the Remote


### PR DESCRIPTION
Since freerdp2-dev contains libfreerdp-shadow.so symlink, I think it should also depend on libfreerdp-shadow2.